### PR TITLE
many: move chooser to initramfs

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -23,6 +23,13 @@ export PYTHONPATH=./ubuntu-image
     -f lib/modules/4.15.0-54-generic/kernel/drivers:/lib/modules/4.15.0-54-generic/kernel/crypto/af_alg.ko \
     -f lib/modules/4.15.0-54-generic/kernel/drivers:/lib/modules/4.15.0-54-generic/kernel/crypto/algif_skcipher.ko \
     -f lib:no-udev.so \
+    -f bin:chooser/chooser \
+    -f lib:/usr/lib/x86_64-linux-gnu/libform.so.5 \
+    -f lib:/usr/lib/x86_64-linux-gnu/libmenu.so.5 \
+    -f lib:/lib/x86_64-linux-gnu/libncurses.so.5 \
+    -f lib:/lib/x86_64-linux-gnu/libtinfo.so.5 \
+    -f lib:/usr/lib/x86_64-linux-gnu/libpanel.so.5 \
+    -f lib/terminfo/l:/lib/terminfo/l/linux \
     pc-kernel_*.snap core-build/initramfs
 
 sudo ./inject-snap.sh \

--- a/console-conf-wrapper
+++ b/console-conf-wrapper
@@ -21,7 +21,6 @@ if [ -f /writable/system-data/chooser.out ]; then
     . /writable/system-data/chooser.out
 fi
 
-# Install mode: recreate writable from recovery
 if [ "$snap_mode" = "install" ]; then
     if [ "$(tty)" = "/dev/tty1" ]; then
         snap recover --install "$uc_recovery_system"
@@ -31,25 +30,11 @@ if [ "$snap_mode" = "install" ]; then
     else
         cat
     fi
-
-# Recover mode: mount existing writable
-# If the selected version is not the one already booted, we need to reboot
-
 elif [ "$snap_mode" = "recover" ]; then
     if [ "$(tty)" = "/dev/tty1" ]; then
-        # FIXME: check versions and reboot if needed
         snap recover "$uc_recovery_system"
         echo "Running system recovery, please wait..."
         echo
-        journalctl -u snapd -f
-    else
-        cat
-    fi
-
-# recover_reboot is the mode set by recover when it needs a new kernel
-elif [ "$snap_mode" = "recover_reboot" ]; then
-    if [ "$(tty)" = "/dev/tty1" ]; then
-        snap recover "$snap_recovery_system"
         journalctl -u snapd -f
     else
         cat

--- a/console-conf-wrapper
+++ b/console-conf-wrapper
@@ -16,11 +16,15 @@ for x in $(cat /proc/cmdline); do
     esac
 done
 
-# Install mode: recreate writable from recovery
 
+if [ -f /writable/system-data/chooser.out ]; then
+    . /writable/system-data/chooser.out
+fi
+
+# Install mode: recreate writable from recovery
 if [ "$snap_mode" = "install" ]; then
     if [ "$(tty)" = "/dev/tty1" ]; then
-        chooser -install -title "Select the recovery version to install:" -timeout 5
+        snap recover --install "$uc_recovery_system"
         echo "Installing system, please wait..."
         echo
         journalctl -u snapd -f
@@ -33,7 +37,8 @@ if [ "$snap_mode" = "install" ]; then
 
 elif [ "$snap_mode" = "recover" ]; then
     if [ "$(tty)" = "/dev/tty1" ]; then
-        chooser -title "Select the recovery system version" -timeout 10
+        # FIXME: check versions and reboot if needed
+        snap recover "$uc_recovery_system"
         echo "Running system recovery, please wait..."
         echo
         journalctl -u snapd -f

--- a/inject-initramfs.sh
+++ b/inject-initramfs.sh
@@ -41,6 +41,7 @@ add_files() {
             list=$(echo ${A[1]} | tr , '\n')
             for f in $list; do
                 echo "Installing $f..."
+                mkdir -p "$fsdir/main/$destdir"
                 cp $f "$fsdir/main/$destdir"
             done
         done


### PR DESCRIPTION
It was decided in London that chooser should be launched from initramfs,
but also be available in the normal system as a means to set up the next
boot of the system.

This change moves the chooser to initramfs, but does not implement the
running system setup capabilities yet, also because the exact mechanism
of setting up the next boot is still undefined.

In initramfs chooser is simpler and relies on reading recovery versions
and writing the chosen recovery version from and to the filesystem
(which removes many ugly hacks from the original implementation).

Note: also requires changes in core-build to actually call the new
chooser from initramfs.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>