### PR TITLE
many: add key unsealing support to initramfs

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -25,6 +25,7 @@ export PYTHONPATH=./ubuntu-image
     -f lib/modules/4.15.0-54-generic/kernel/drivers:/lib/modules/4.15.0-54-generic/kernel/arch/x86/crypto/glue_helper.ko \
     -f lib/modules/4.15.0-54-generic/kernel/drivers:/lib/modules/4.15.0-54-generic/kernel/crypto/af_alg.ko \
     -f lib/modules/4.15.0-54-generic/kernel/drivers:/lib/modules/4.15.0-54-generic/kernel/crypto/algif_skcipher.ko \
+    -f bin:go/unlock \
     -f lib:no-udev.so \
     -f bin:chooser/chooser \
     -f lib:/usr/lib/x86_64-linux-gnu/libform.so.5 \
@@ -34,6 +35,7 @@ export PYTHONPATH=./ubuntu-image
     -f lib:/usr/lib/x86_64-linux-gnu/libpanel.so.5 \
     -f lib/terminfo/l:/lib/terminfo/l/linux \
     pc-kernel_*.snap core-build/initramfs
+
 
 sudo ./inject-snap.sh \
     -o core20_*.snap \

--- a/prepare.sh
+++ b/prepare.sh
@@ -67,6 +67,24 @@ get_snapd_uc20() {
     done
 }
 
+get_fde_utils() {
+    REPO="https://github.com/chrisccoulson/ubuntu-core-fde-utils"
+    BRANCH="master"
+
+    GOPATH="$(pwd)/go"
+    DST="$GOPATH/src/github.com/chrisccoulson/ubuntu-core-fde-utils"
+
+    # fake GOPATH
+    export GOPATH
+    mkdir -p "$DST"
+    if [ ! -d "$DST/unlock" ]; then
+        git clone -b "$BRANCH" "$REPO" "$DST"
+    fi
+    (cd "$DST"/vendor && govendor sync)
+
+    go build -o go/unlock github.com/chrisccoulson/ubuntu-core-fde-utils/unlock
+}
+
 if [ ! -d ./ubuntu-image ]; then
     get_ubuntu_image
 fi
@@ -82,6 +100,10 @@ fi
 #        we can just use the "snapd" snap from channel=20
 if [ ! -x ./go/snap ]; then
     get_snapd_uc20
+fi
+
+if [ ! -x ./go/unlock ]; then
+    get_fde_utils
 fi
 
 if [ ! -e core20-mvo-amd64.model ]; then


### PR DESCRIPTION
The master key to the LUKS device containing ubuntu-data is now sealed
to the TPM. Add the components needed to unseal the key and open the
device to our initramfs.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>