### PR TITLE
build-image.sh: warn if no bind mount for /usr/bin/snap is in place

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -4,6 +4,12 @@ set -e
 
 export PYTHONPATH=./ubuntu-image
 
+if ! grep -q /usr/bin/snap /proc/self/mountinfo; then
+    echo "No bind mount of /usr/bin/snap found, please run:"
+    echo "./build-snapd.sh"
+    exit 1
+fi
+
 ./inject-initramfs.sh \
     -o pc-kernel_*.snap \
     -f bin:/usr/bin/grub-editenv \


### PR DESCRIPTION
Without the bind mount snap preapre-image will not DTRT.