### PR TITLE
Fix ubuntu-image building error on mtools

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -48,6 +48,9 @@ sudo ./inject-snap.sh \
     -f usr/bin:go/snap \
     snapd_*.snap
 
+#skip mtools warning
+export MTOOLS_SKIP_CHECK=1
+
 ubuntu-image/ubuntu-image snap \
     --image-size 4G \
     --snap pc_*.snap \


### PR DESCRIPTION
When building image by the build-image.sh script, there is an error message complaining the recovery partition sectors are not multiple of sectors per track:
```
WARNING: "snapd", "core20", "pc-kernel" were installed from local snaps disconnected from a store and cannot be refreshed subsequently!
COMMAND FAILED: mcopy -s -i /tmp/tmpsw7mx8y4/volumes/pc/part2.img /tmp/tmpsw7mx8y4/root/systems /tmp/tmpsw7mx8y4/root/boot /tmp/tmpsw7mx8y4/root/snaps ::

Total number of sectors (2457600) not a multiple of sectors per track (63)!
Add mtools_skip_check=1 to your .mtoolsrc file to skip this test

Crash in state machine
Traceback (most recent call last):
  File "/home/tim/canonical/spike-tools/ubuntu-image/ubuntu_image/__main__.py", line 360, in main
    list(state_machine)
  File "/home/tim/canonical/spike-tools/ubuntu-image/ubuntu_image/state.py", line 82, in __next__
    step()
  File "/home/tim/canonical/spike-tools/ubuntu-image/ubuntu_image/common_builder.py", line 418, in populate_filesystems
    self._populate_one_volume(name, volume)
  File "/home/tim/canonical/spike-tools/ubuntu-image/ubuntu_image/common_builder.py", line 408, in _populate_one_volume
    part_img, sourcefiles, env=env))
  File "/home/tim/canonical/spike-tools/ubuntu-image/ubuntu_image/helpers.py", line 122, in run
    proc.check_returncode()
  File "/usr/lib/python3.6/subprocess.py", line 389, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command '['mcopy', '-s', '-i', '/tmp/tmpsw7mx8y4/volumes/pc/part2.img', '/tmp/tmpsw7mx8y4/root/systems', '/tmp/tmpsw7mx8y4/root/boot', '/tmp/tmpsw7mx8y4/root/snaps', '::']'
```
This commit should be able to workaround the issue in the script (without adding .mtoolsrc separately) 

If feasible, we should consider making total number of sectors for recovery partition multiple of sectors per track. For example, allocate 1280M instead of 1200M in the gadget snap.
