### PR TITLE
many: generate and use secure boot keys

### DIFF
--- a/README
+++ b/README
@@ -1,10 +1,11 @@
 
-
 To run the spike:
 
 ./prepare.sh
 ./build-image.sh
 ./run-test.sh
+
+Secure boot keys must be manually enrolled in OVMF.
 
 
 If you're hacking snapd:
@@ -12,13 +13,4 @@ If you're hacking snapd:
 ./build-snapd.sh
 ./build-image.sh
 ./run-test.sh
-
-
-
-
-Approx. run times (qemu running on AMD R7 2700 w/ spinning disk):
-
-- from boot to version chooser: 40s
-- install time: approx. 30s
-- installed system to console-conf: 40s
 

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,7 +1,35 @@
 #!/bin/sh
 
+TPM=tpm
+
+usage() {
+    echo "Usage: $0 [-c]"
+    exit
+}
+
+while getopts "hc" opt; do
+    case "${opt}" in
+        c)
+            rm "$TPM"/*
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+
+mkdir -p "$TPM"
+echo "Starting $TPM"
+sudo swtpm socket --tpmstate dir="$TPM" --tpm2 --ctrl type=unixio,path="$TPM"/swtpm-sock &
+sleep 2 # this should be changed to a netstat query
+
 sudo kvm \
-  -bios /usr/share/ovmf/OVMF.fd \
   -smp 2 -m 256 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 \
   -device virtio-net-pci,netdev=mynet0 \
-  -drive file=pc.img,format=raw
+  -pflash /usr/share/OVMF/OVMF_CODE.fd \
+  -drive file=OVMF_VARS.fd,if=pflash,format=raw \
+  -chardev socket,id=chrtpm,path="$TPM"/swtpm-sock -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0 \
+  -drive file=pc.img,format=raw \
+  -drive file=sbtestdb/drive.img


### PR DESCRIPTION
Generate a set of PK, KEK and UEFI keys and download the Microsoft
CA certificate, and add make them ready of enroll in OVMF. Update
the qemu command line parameters to use OVMF_CODE and OVMF_VARS.
Note: keys must be enrolled manually in the OVMF interface.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>