### PR TITLE
inject-initramfs: fix depmod kernel version

### DIFF
--- a/inject-initramfs.sh
+++ b/inject-initramfs.sh
@@ -57,7 +57,7 @@ add_modules() {
             find "$rootdir/modules/$kver/" -name "$mod" -exec cp {} \
                 "$fsdir/main/lib/modules/$kver/kernel/drivers/" \;
         done
-        depmod -b "$fsdir/main" 4.15.0-54-generic
+        depmod -b "$fsdir/main" "$kver"
     fi
 }
 


### PR DESCRIPTION
When running depmod, use the detected version instead of a hardwired
one.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>