### PR TITLE
many: refactor chooser to read user keypress

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -28,6 +28,7 @@ export PYTHONPATH=./ubuntu-image
     -f bin:go/unlock \
     -f lib:no-udev.so \
     -f bin:chooser/chooser \
+    -f bin:check-trigger/check-trigger \
     -f lib:/usr/lib/x86_64-linux-gnu/libform.so.5 \
     -f lib:/usr/lib/x86_64-linux-gnu/libmenu.so.5 \
     -f lib:/lib/x86_64-linux-gnu/libncurses.so.5 \

--- a/check-trigger/Makefile
+++ b/check-trigger/Makefile
@@ -1,0 +1,19 @@
+CC      = gcc
+CFLAGS  = -Wall
+LD      = gcc
+LDFLAGS = 
+OBJS    = main.o
+LIBS    =
+
+.c.o:
+	$(CC) -c -o $*.o $<
+
+check-trigger: $(OBJS)
+	$(LD) -o $@ $(OBJS) $(LIBS)
+
+$(OBJS): Makefile
+
+main.o: main.c
+ 
+clean:
+	rm -f $(OBJS) *~

--- a/check-trigger/main.c
+++ b/check-trigger/main.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <linux/keyboard.h>
+
+/*
+ * Sample vendor-supplied boot time recovery trigger detector.
+ * Returns 0 if the shift key is pressed, 1 otherwise.
+ */
+
+int main()
+{
+    int fd;
+    char shift_state = 6;
+
+    if ((fd = open("/dev/console", O_RDONLY)) < 0) {
+        exit(EXIT_FAILURE);
+    }
+    if (ioctl(fd, TIOCLINUX, &shift_state) < 0) {
+        exit(EXIT_FAILURE);
+    }
+
+    exit((shift_state & (1 << KG_SHIFT)) ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/chooser/chooser.go
+++ b/chooser/chooser.go
@@ -5,70 +5,62 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
+	"os/exec"
 	"path"
 	"time"
 
-	nc "github.com/gbin/goncurses"
+	nc "github.com/rthornton128/goncurses"
 )
 
-var name string
-
-func main() {
-
-	title := flag.String("title", "Choose the recovery version", "Menu title")
-	output := flag.String("output", "/run/chooser.out", "Output file location")
-	seed := flag.String("seed", "/run/ubuntu-seed", "Ubuntu-seed location")
-	timeout := flag.Int("timeout", 5, "Timeout in seconds")
-	flag.Parse()
-
-	versions, err := getRecoveryVersions(*seed)
-	if err != nil {
-		log.Fatalf("cannot get recovery versions: %s", err)
-	}
-
-	version, err := getSelection(*title, *timeout, versions)
-	if err != nil {
-		log.Fatalf("cannot get selected version: %s", err)
-	}
-
-	config := fmt.Sprintf("uc_recovery_system=%q", version)
-	if err := ioutil.WriteFile(*output, []byte(config), 0644); err != nil {
-		log.Fatalf("cannot write configuration file: %s", err)
-		os.Exit(1)
-	}
+type Chooser struct {
+	scr *nc.Window
 }
 
-func getSelection(title string, timeout int, versions []string) (string, error) {
-	scr, err := nc.Init()
+func (c *Chooser) Init() error {
+	var err error
+	c.scr, err = nc.Init()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
-	defer nc.End()
 
 	nc.Raw(true)
 	nc.Echo(false)
 	nc.Cursor(0)
-	scr.Clear()
-	scr.Keypad(true)
+	c.scr.Timeout(0)
+	c.scr.Clear()
+	c.scr.Keypad(true)
 
-	scr.Println(title)
+	return nil
+}
 
-	items := make([]*nc.MenuItem, len(versions))
-	for i, val := range versions {
-		items[i], _ = nc.NewItem(val, "")
+func (c *Chooser) Deinit() {
+	nc.End()
+}
+
+type MenuOption struct {
+	text    string
+	handler func(*Chooser, ...interface{})
+}
+
+func (c *Chooser) DisplayMenu(title string, timeout int, options []MenuOption) (int, error) {
+	c.scr.Clear()
+	c.scr.Println(title)
+
+	items := make([]*nc.MenuItem, len(options))
+	for i, option := range options {
+		items[i], _ = nc.NewItem(option.text, "")
 		defer items[i].Free()
 	}
 
 	menu, err := nc.NewMenu(items)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 	defer menu.Free()
 
 	win, err := nc.NewWindow(10, 40, 2, 0)
 	if err != nil {
-		return "", err
+		return 0, err
 	}
 	win.Keypad(true)
 
@@ -76,7 +68,7 @@ func getSelection(title string, timeout int, versions []string) (string, error) 
 	menu.SubWindow(win.Derived(5, 36, 1, 3))
 	menu.Mark("> ")
 
-	scr.Refresh()
+	c.scr.Refresh()
 
 	menu.Post()
 	defer menu.UnPost()
@@ -85,7 +77,9 @@ func getSelection(title string, timeout int, versions []string) (string, error) 
 	countch := make(chan int)
 	keych := make(chan nc.Key)
 
-	go countdown(countch, timeout)
+	if timeout > 0 {
+		go countdown(countch, timeout)
+	}
 	go readkey(keych, win)
 
 	for {
@@ -95,7 +89,7 @@ func getSelection(title string, timeout int, versions []string) (string, error) 
 
 			switch nc.KeyString(ch) {
 			case "enter":
-				return menu.Current(nil).Name(), nil
+				return menu.Current(nil).Index(), nil
 			case "down":
 				menu.Driver(nc.REQ_DOWN)
 			case "up":
@@ -106,10 +100,102 @@ func getSelection(title string, timeout int, versions []string) (string, error) 
 			win.MovePrint(8, 0, fmt.Sprintf("Time to select: %2d ", t))
 			win.Refresh()
 			if t == 0 {
-				return menu.Current(nil).Name(), nil
+				return menu.Current(nil).Index(), nil
 			}
 		}
 	}
+}
+
+//
+
+func main() {
+	title := flag.String("title", "Choose the recovery version", "Menu title")
+	output := flag.String("output", "/run/chooser.out", "Output file location")
+	seed := flag.String("seed", "/run/ubuntu-seed", "Ubuntu-seed location")
+	timeout := flag.Int("timeout", 5, "Timeout in seconds")
+	check := flag.Bool("check", false, "Check if magic trigger is active")
+	flag.Parse()
+
+	// Wait for trigger to run the chooser
+	if *check && !checkTrigger() {
+		return
+	}
+
+	c := &Chooser{}
+	c.Init()
+	defer c.Deinit()
+
+	if !*check {
+		chooseSystem(c, *title, *seed, *output, *timeout)
+		return
+	}
+
+	mainMenu := []MenuOption{
+		{"Run", runHandler},
+		{"Recover", recoverHandler},
+		{"Reset", resetHandler},
+		{"Advanced", advancedHandler},
+	}
+
+	opt, err := c.DisplayMenu("Choose mode", 0, mainMenu)
+	if err != nil {
+		c.Deinit()
+		log.Fatalf("internal error: %s", err)
+	}
+	mainMenu[opt].handler(c, *seed, *output)
+}
+
+func checkTrigger() bool {
+	fmt.Println("Checking recovery trigger...")
+	time.Sleep(2 * time.Second)
+	return exec.Command("/bin/check-trigger").Run() == nil
+}
+
+func runHandler(c *Chooser, parms ...interface{}) {
+	// do nothing
+}
+
+func recoverHandler(c *Chooser, parms ...interface{}) {
+	// set system to boot in recover mode
+}
+
+func resetHandler(c *Chooser, parms ...interface{}) {
+	// restore to factory?
+}
+
+func advancedHandler(c *Chooser, parms ...interface{}) {
+	// allow user to choose an action for a recovery version
+	seed := parms[0].(string)
+	output := parms[1].(string)
+	chooseSystem(c, "Choose a recovery system:", seed, output, 0)
+}
+
+func chooseSystem(c *Chooser, title, seedDir, output string, timeout int) string {
+	versions, err := getRecoveryVersions(seedDir)
+	if err != nil {
+		log.Fatalf("cannot get recovery versions: %s", err)
+	}
+
+	versionOptions := make([]MenuOption, len(versions))
+	for i, ver := range versions {
+		versionOptions[i] = MenuOption{ver, nil}
+	}
+
+	index, err := c.DisplayMenu(title, timeout, versionOptions)
+	if err != nil {
+		log.Fatalf("cannot display menu: %s", err)
+	}
+	version := versionOptions[index].text
+
+	if len(output) > 0 {
+		config := fmt.Sprintf("uc_recovery_system=%q", version)
+		if err := ioutil.WriteFile(output, []byte(config), 0644); err != nil {
+			c.Deinit()
+			log.Fatalf("cannot write configuration file: %s", err)
+		}
+	}
+
+	return version
 }
 
 func readkey(keych chan nc.Key, win *nc.Window) {

--- a/prepare.sh
+++ b/prepare.sh
@@ -9,10 +9,14 @@ build_udev_hack() {
 
 build_chooser() {
     sudo apt install libncursesw5-dev libncurses5-dev
-    go get github.com/gbin/goncurses
+    go get github.com/rthornton128/goncurses
     (cd chooser &&
      go build chooser.go
     )
+}
+
+build_check_trigger() {
+    make -C check-trigger
 }
 
 get_ubuntu_image() {
@@ -125,6 +129,10 @@ snap download --channel=20/edge pc
 
 if [ ! -x chooser/chooser ]; then
     build_chooser
+fi
+
+if [ ! -x check-trigger/check-trigger ]; then
+    build_check_trigger
 fi
 
 if [ ! -f no-udev.so ]; then

--- a/run-test.sh
+++ b/run-test.sh
@@ -26,7 +26,7 @@ sudo swtpm socket --tpmstate dir="$TPM" --tpm2 --ctrl type=unixio,path="$TPM"/sw
 sleep 2 # this should be changed to a netstat query
 
 sudo kvm \
-  -smp 2 -m 256 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 \
+  -smp 2 -m 512 -netdev user,id=mynet0,hostfwd=tcp::8022-:22,hostfwd=tcp::8090-:80 \
   -device virtio-net-pci,netdev=mynet0 \
   -pflash /usr/share/OVMF/OVMF_CODE.fd \
   -drive file=OVMF_VARS.fd,if=pflash,format=raw \


### PR DESCRIPTION
We plan to hide grub so we need a way to read the user input on boot
to select a different mode. In the real case the device vendor should
supply the magic trigger detector in the gadget snap, so we're running
a separate executable here to do that.

We have different strategies to detect the keypress: we can check for
an actual keypress, or see if the key is already pressed. This
implementation uses the latter for the Shift key, but the key still
needs to be pressed *after* the kernel starts to boot, and the actual
window is very small. We must find a better solution.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>