### PR TITLE
many: run recover mode if triggered

### DIFF
--- a/chooser/chooser.go
+++ b/chooser/chooser.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os/exec"
 	"path"
 	"time"
 
@@ -113,42 +112,29 @@ func main() {
 	output := flag.String("output", "/run/chooser.out", "Output file location")
 	seed := flag.String("seed", "/run/ubuntu-seed", "Ubuntu-seed location")
 	timeout := flag.Int("timeout", 5, "Timeout in seconds")
-	check := flag.Bool("check", false, "Check if magic trigger is active")
 	flag.Parse()
-
-	// Wait for trigger to run the chooser
-	if *check && !checkTrigger() {
-		return
-	}
 
 	c := &Chooser{}
 	c.Init()
 	defer c.Deinit()
 
-	if !*check {
-		chooseSystem(c, *title, *seed, *output, *timeout)
-		return
-	}
+	chooseSystem(c, *title, *seed, *output, *timeout)
 
-	mainMenu := []MenuOption{
-		{"Run", runHandler},
-		{"Recover", recoverHandler},
-		{"Reset", resetHandler},
-		{"Advanced", advancedHandler},
-	}
+	/*
+		mainMenu := []MenuOption{
+			{"Run", runHandler},
+			{"Recover", recoverHandler},
+			{"Reset", resetHandler},
+			{"Advanced", advancedHandler},
+		}
 
-	opt, err := c.DisplayMenu("Choose mode", 0, mainMenu)
-	if err != nil {
-		c.Deinit()
-		log.Fatalf("internal error: %s", err)
-	}
-	mainMenu[opt].handler(c, *seed, *output)
-}
-
-func checkTrigger() bool {
-	fmt.Println("Checking recovery trigger...")
-	time.Sleep(2 * time.Second)
-	return exec.Command("/bin/check-trigger").Run() == nil
+		opt, err := c.DisplayMenu("Choose mode", 0, mainMenu)
+		if err != nil {
+			c.Deinit()
+			log.Fatalf("internal error: %s", err)
+		}
+		mainMenu[opt].handler(c, *seed, *output)
+	*/
 }
 
 func runHandler(c *Chooser, parms ...interface{}) {

--- a/console-conf-wrapper
+++ b/console-conf-wrapper
@@ -16,6 +16,9 @@ for x in $(cat /proc/cmdline); do
     esac
 done
 
+if [ -f /writable/system-data/.recover ]; then
+    snap_mode="recovery"
+fi
 
 if [ -f /writable/system-data/chooser.out ]; then
     . /writable/system-data/chooser.out


### PR DESCRIPTION
If the magic trigger key is detected, switch to recover mode, running
under the currently booted kernel if possible. If a different recovery
system is selected, we'll have to reboot.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>