### PR TITLE
prepare.sh: check if fde-utils has vendored packages

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -59,8 +59,11 @@ get_fde_utils() {
     mkdir -p "$DST"
     if [ ! -d "$DST/unlock" ]; then
         git clone -b "$BRANCH" "$REPO" "$DST"
+        (cd "$DST" && go get -v -d ./...)
     fi
-    (cd "$DST"/vendor && govendor sync)
+    if [ -f "$DST"/vendor/vendor.json ]; then
+        (cd "$DST" && govendor sync)
+    fi
 
     go build -o go/unlock github.com/chrisccoulson/ubuntu-core-fde-utils/unlock
 }


### PR DESCRIPTION
Before running govendor in ubuntu-core-fde-utils, check if there are
any vendored packages to sync. Fde-utils is unstable and vendored
packages may be added or removed during development.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>